### PR TITLE
#14: Deploy main with github actions and document it

### DIFF
--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -1,0 +1,26 @@
+# This workflow runs on all merges to main
+
+name: Deploy main after each merge
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+    branches:
+      - main
+
+jobs:
+  deploy-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Deploy to cloud.gov
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_USERNAME }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: sandbox-gsa
+          cf_space: neil.martinsen-burrell
+          cf_manifest: "ops/manifests/manifest.yaml"

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,38 @@
+# Operations
+
+This prototype runs on Cloud.gov using their Staticfile buildpack where it
+simply serves files from the `/site/` directory of this repository.
+
+## Infrastructure
+
+The Cloud.gov infrastructure is simple. There is a single app in a single
+space. If there is an org and a space, then the app can be pushed according
+to the manifest in `ops/manifests/manifest.yaml`.
+
+```bash
+$ cf push -f ops/manifests/manifest.yaml
+```
+
+## Deployment
+
+Deploys are automatic from the `main` branch whenever a pull request is merged,
+using the workflow in `.github/workflows/deploy-main.yaml`. For continuous
+deployment, we need Cloud.gov credentials for the deploy user in Github Actions
+
+```bash
+$ cf create-service cloud-gov-service-account space-deployer github-cd-account
+[...]
+$ cf create-service-key github-cd-account github-cd-key
+[...]
+$ cf service-key github-cd-account github-cd-key
+Getting key github-cd-key for service instance github-cd-account as neil.martinsen-burrell@gsa.gov...
+
+{
+ "password": "....",
+ "username": "...."
+}
+```
+
+And those values of `username` and `password` are stored in Github Actions
+secrets called `CF_USERNAME` and `CF_PASSWORD` at
+<https://github.com/18F/usfs-special-uses-prototype/settings/secrets/actions>

--- a/ops/manifests/manifest.yaml
+++ b/ops/manifests/manifest.yaml
@@ -1,0 +1,3 @@
+---
+applications:
+- name: special-uses


### PR DESCRIPTION
This deploys every merge to our `main` branch onto Cloud.gov. It also adds documentation in the `ops/` directory about the infrastructure and the deploy setup.

This would close the issue #14 but it won't be tested until this is merged and we see what happens with the workflow.