### PR TITLE
Fix main deploy workflow by adding dev dependencies

### DIFF
--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -16,8 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-node@v4
+
+      - name: Install node dependencies
+        run: npm ci
+
       - name: Build with Eleventy
-        uses: TartanLlama/actions-eleventy@master
+        run: npm run build
 
       - name: Deploy to cloud.gov
         uses: cloud-gov/cg-cli-tools@main


### PR DESCRIPTION
Our new eleventy build needs more dependencies installed, so do the same thing here that we do in `test.yaml`.