### PR TITLE
84: Store form question answers client-side and use them on a summary page

### DIFF
--- a/site/assets/js/formstorage.js
+++ b/site/assets/js/formstorage.js
@@ -2,9 +2,9 @@
 if (document.readyState !== 'loading') {
   attachFormsSubmitHandler();
 } else {
-	window.addEventListener("DOMContentLoaded", function () {
-		attachFormsSubmitHandler();
-	});
+  window.addEventListener("DOMContentLoaded", function () {
+    attachFormsSubmitHandler();
+  });
 }
 
 function attachFormsSubmitHandler() {
@@ -17,12 +17,12 @@ function attachFormsSubmitHandler() {
 }
 
 function saveSubmittedData(event) {
-	console.log("Handling submit button click");
+  console.log("Handling submit button click");
   console.log("Event sent from", event.target, "with submitter", event.submitter);
   var formData = new FormData(event.target, event.submitter);
 
   for (const [name, value] of formData) {
-		// form a key to save the data include .name and set that to .value in sessionStorage
+    // form a key to save the data include .name and set that to .value in sessionStorage
     const key = "form-save-submit-" + event.target.id + "-" + name;
     window.sessionStorage.setItem(key, value);
   }

--- a/site/assets/js/formstorage.js
+++ b/site/assets/js/formstorage.js
@@ -1,0 +1,29 @@
+// Store form submission information into sessionStorage
+if (document.readyState !== 'loading') {
+  attachFormsSubmitHandler();
+} else {
+	window.addEventListener("DOMContentLoaded", function () {
+		attachFormsSubmitHandler();
+	});
+}
+
+function attachFormsSubmitHandler() {
+  var forms = document.getElementsByClassName("form-submit-save");
+
+  for (const form of forms) {
+    // there was at least one form on the page
+    form.addEventListener("submit", saveSubmittedData);
+  };
+}
+
+function saveSubmittedData(event) {
+	console.log("Handling submit button click");
+  console.log("Event sent from", event.target, "with submitter", event.submitter);
+  var formData = new FormData(event.target, event.submitter);
+
+  for (const [name, value] of formData) {
+		// form a key to save the data include .name and set that to .value in sessionStorage
+    const key = "form-save-submit-" + event.target.id + "-" + name;
+    window.sessionStorage.setItem(key, value);
+  }
+}

--- a/site/assets/js/formsummary.js
+++ b/site/assets/js/formsummary.js
@@ -18,18 +18,13 @@ function fillSummaryInformation() {
   console.log("div has dd elements", descriptionElements);
 
   for (const element of descriptionElements) {
-    console.log("Updating value for element", element);
     // each dd element has a data-field-key attribute that
     // is used to build the key into sessionStorage
     var fieldKey = element.attributes["data-field-key"].value;
-    console.log("Got field key", fieldKey);
     if (fieldKey != null) {
       const storageKey = "form-save-submit-" + fieldKey;
       var itemValue = window.sessionStorage.getItem(storageKey);
-      console.log("Found session storage value", itemValue);
       element.textContent = itemValue;
-    } else {
-      console.log("dd element has no data-field-key");
     }
   }
 }

--- a/site/assets/js/formsummary.js
+++ b/site/assets/js/formsummary.js
@@ -2,9 +2,9 @@
 if (document.readyState !== 'loading') {
   fillSummaryInformation();
 } else {
-	window.addEventListener("DOMContentLoaded", function () {
-		fillSummaryInformation();
-	});
+  window.addEventListener("DOMContentLoaded", function () {
+    fillSummaryInformation();
+  });
 }
 
 function fillSummaryInformation() {

--- a/site/assets/js/formsummary.js
+++ b/site/assets/js/formsummary.js
@@ -1,0 +1,35 @@
+// Fill summary information from sessionStorage
+if (document.readyState !== 'loading') {
+  fillSummaryInformation();
+} else {
+	window.addEventListener("DOMContentLoaded", function () {
+		fillSummaryInformation();
+	});
+}
+
+function fillSummaryInformation() {
+  // summary information is in sesstionStorage
+  // keys are prefixed with form-save-submit-
+
+  // fields to fill in are in <dd> elements under a div
+  // with ID form-summary
+  var summaryDiv = document.getElementById("form-summary");
+  var descriptionElements = summaryDiv.getElementsByTagName("dd");
+  console.log("div has dd elements", descriptionElements);
+
+  for (const element of descriptionElements) {
+    console.log("Updating value for element", element);
+    // each dd element has a data-field-key attribute that
+    // is used to build the key into sessionStorage
+    var fieldKey = element.attributes["data-field-key"].value;
+    console.log("Got field key", fieldKey);
+    if (fieldKey != null) {
+      const storageKey = "form-save-submit-" + fieldKey;
+      var itemValue = window.sessionStorage.getItem(storageKey);
+      console.log("Found session storage value", itemValue);
+      element.textContent = itemValue;
+    } else {
+      console.log("dd element has no data-field-key");
+    }
+  }
+}

--- a/src/_includes/layouts/question.njk
+++ b/src/_includes/layouts/question.njk
@@ -2,6 +2,8 @@
 layout: layouts/base.njk
 ---
 
+<script type="text/javascript" src="/assets/js/formstorage.js"></script>
+
 <div class="about">
 <div class="container">
 <div class="content">

--- a/src/question1.html
+++ b/src/question1.html
@@ -10,7 +10,7 @@ Special use permits are used in Forest Service for many different types of activ
 </p>
 
 
-<form class="usa-form usa-form--large" action="/question2/" method="get">
+<form id="usetype-form" class="usa-form usa-form--large form-submit-save" action="/question2/" method="get">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend">Please select your use.</legend>
 

--- a/src/question2.html
+++ b/src/question2.html
@@ -14,7 +14,7 @@ We need to know if you already have a permit or if you want to get a new permit.
 </p>
 
 
-<form class="usa-form usa-form--large" action="/question1/" method="get">
+<form id="existing-form" class="usa-form usa-form--large form-submit-save" action="/question1/" method="get">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend">Do you have an existing permit?</legend>
 

--- a/src/question2.html
+++ b/src/question2.html
@@ -14,7 +14,7 @@ We need to know if you already have a permit or if you want to get a new permit.
 </p>
 
 
-<form id="existing-form" class="usa-form usa-form--large form-submit-save" action="/question1/" method="get">
+<form id="existing-form" class="usa-form usa-form--large form-submit-save" action="/summary/" method="get">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend">Do you have an existing permit?</legend>
 

--- a/src/summary.html
+++ b/src/summary.html
@@ -1,0 +1,24 @@
+---
+layout: layouts/question.njk
+title: Form summary
+---
+
+<script type="text/javascript" src="/assets/js/formsummary.js"></script>
+
+<h1>Your information so far</h1>
+
+<p>Here is a summary of the information you have submitted so far:</p>
+
+<div id="form-summary">
+
+  <dl>
+
+    <dt>Use type:</dt>
+    <dd data-field-key="usetype-form-usetype"></dd>
+
+    <dt>Existing permit:</dt>
+    <dd data-field-key="existing-form-existing"></dd>
+
+  </ul>
+
+</div>


### PR DESCRIPTION
#84 asks for a way to store the answers to forms on the browser because we are not running a web app, so we don't have server-side storage to accumulate form answers. This adds that capability using the browser's `sessionStorage` which is cleared each time a tab is closed. This should minimize the impact of long-lived form responses getting in the way of future efforts to fill out the form.

![Screenshot 2024-09-09 at 2 53 05 PM](https://github.com/user-attachments/assets/5b6a742b-d9ce-4daa-b738-040dfa4afbbb)

The summary page is extremely basic, but it allows for specifying in an HTML page the keys that should be used to look a form value up in `sessionStorage`. A very simple Javascript routine then fills in the elements on the page from storage.

Closes #84.